### PR TITLE
Add comments on trash posts

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -91,11 +91,29 @@ func (db *DB) migrate() error {
 		return fmt.Errorf("failed to create trash_posts table: %w", err)
 	}
 
+	// Create comments table
+	createCommentsTable := `
+       CREATE TABLE IF NOT EXISTS comments (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               post_id INTEGER NOT NULL,
+               user_id INTEGER NOT NULL,
+               content TEXT NOT NULL,
+               created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+               FOREIGN KEY (post_id) REFERENCES trash_posts(id) ON DELETE CASCADE,
+               FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+       );`
+
+	if _, err := db.Exec(createCommentsTable); err != nil {
+		return fmt.Errorf("failed to create comments table: %w", err)
+	}
+
 	// Create indexes
 	createIndexes := []string{
 		"CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);",
 		"CREATE INDEX IF NOT EXISTS idx_trash_user_id ON trash_posts(user_id);",
 		"CREATE INDEX IF NOT EXISTS idx_trash_created_at ON trash_posts(created_at);",
+		"CREATE INDEX IF NOT EXISTS idx_comments_post_id ON comments(post_id);",
+		"CREATE INDEX IF NOT EXISTS idx_comments_created_at ON comments(created_at);",
 	}
 
 	for _, query := range createIndexes {

--- a/handlers/comment.go
+++ b/handlers/comment.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"strconv"
+
+	"gobackend/models"
+
+	"github.com/valyala/fasthttp"
+)
+
+// CommentHandler handles comment endpoints
+type CommentHandler struct {
+	repo     *models.CommentRepository
+	userRepo *models.UserRepository
+}
+
+func NewCommentHandler(repo *models.CommentRepository, userRepo *models.UserRepository) *CommentHandler {
+	return &CommentHandler{repo: repo, userRepo: userRepo}
+}
+
+// createCommentRequest represents the payload for creating a comment
+type createCommentRequest struct {
+	Content string `json:"content"`
+}
+
+// CreateComment adds a new comment to a post
+func (h *CommentHandler) CreateComment(ctx *fasthttp.RequestCtx) {
+	postIDStr := ctx.UserValue("id").(string)
+	postID, err := strconv.Atoi(postIDStr)
+	if err != nil {
+		writeJSON(ctx, fasthttp.StatusBadRequest, map[string]string{"error": "invalid post id"})
+		return
+	}
+
+	userID, err := getUserIDFromToken(ctx)
+	if err != nil {
+		writeJSON(ctx, fasthttp.StatusUnauthorized, map[string]string{"error": err.Error()})
+		return
+	}
+
+	var req createCommentRequest
+	if err := readJSON(ctx, &req); err != nil {
+		writeJSON(ctx, fasthttp.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	user, err := h.userRepo.GetByID(userID)
+	if err != nil || user == nil {
+		writeJSON(ctx, fasthttp.StatusBadRequest, map[string]string{"error": "invalid user"})
+		return
+	}
+
+	c := models.Comment{PostID: postID, UserID: userID, Content: req.Content, User: user}
+	if err := h.repo.Create(&c); err != nil {
+		writeJSON(ctx, fasthttp.StatusInternalServerError, map[string]string{"error": "failed to create comment"})
+		return
+	}
+
+	writeJSON(ctx, fasthttp.StatusCreated, c)
+}
+
+// GetComments returns comments for a post
+func (h *CommentHandler) GetComments(ctx *fasthttp.RequestCtx) {
+	postIDStr := ctx.UserValue("id").(string)
+	postID, err := strconv.Atoi(postIDStr)
+	if err != nil {
+		writeJSON(ctx, fasthttp.StatusBadRequest, map[string]string{"error": "invalid post id"})
+		return
+	}
+
+	comments, err := h.repo.GetByPostID(postID)
+	if err != nil {
+		writeJSON(ctx, fasthttp.StatusInternalServerError, map[string]string{"error": "failed to get comments"})
+		return
+	}
+
+	writeJSON(ctx, fasthttp.StatusOK, comments)
+}

--- a/main.go
+++ b/main.go
@@ -30,9 +30,11 @@ func main() {
 
 	userRepo := models.NewUserRepository(db.DB)
 	trashRepo := models.NewTrashPostRepository(db.DB)
+	commentRepo := models.NewCommentRepository(db.DB)
 
 	userHandler := handlers.NewUserHandler(userRepo)
 	trashHandler := handlers.NewTrashPostHandler(trashRepo, userRepo)
+	commentHandler := handlers.NewCommentHandler(commentRepo, userRepo)
 	oauthHandler := handlers.NewOAuthHandler(userRepo)
 
 	r := router.New()
@@ -50,6 +52,8 @@ func main() {
 	r.POST("/trashposts", trashHandler.CreateTrashPost)
 	r.GET("/trashposts", trashHandler.GetTrashPosts)
 	r.DELETE("/trashposts/{id}", trashHandler.DeleteTrashPost)
+	r.POST("/trashposts/{id}/comments", commentHandler.CreateComment)
+	r.GET("/trashposts/{id}/comments", commentHandler.GetComments)
 
 	server := &fasthttp.Server{Handler: r.Handler}
 

--- a/models/comment.go
+++ b/models/comment.go
@@ -1,0 +1,64 @@
+package models
+
+import (
+	"database/sql"
+	"time"
+)
+
+// Comment represents a comment on a trash post
+type Comment struct {
+	ID        int       `json:"id" db:"id"`
+	PostID    int       `json:"post_id" db:"post_id"`
+	UserID    int       `json:"user_id" db:"user_id"`
+	User      *User     `json:"user,omitempty"`
+	Content   string    `json:"content" db:"content"`
+	CreatedAt time.Time `json:"created_at" db:"created_at"`
+}
+
+// CommentRepository handles comment database operations
+type CommentRepository struct {
+	db *sql.DB
+}
+
+// NewCommentRepository creates a new repository
+func NewCommentRepository(db *sql.DB) *CommentRepository {
+	return &CommentRepository{db: db}
+}
+
+// Create inserts a new comment into the database
+func (r *CommentRepository) Create(c *Comment) error {
+	query := `
+        INSERT INTO comments (post_id, user_id, content)
+        VALUES (?, ?, ?)
+        RETURNING id, created_at`
+	return r.db.QueryRow(query, c.PostID, c.UserID, c.Content).Scan(&c.ID, &c.CreatedAt)
+}
+
+// GetByPostID retrieves all comments for a given post
+func (r *CommentRepository) GetByPostID(postID int) ([]*Comment, error) {
+	query := `
+        SELECT c.id, c.post_id, c.user_id, c.content, c.created_at,
+               u.id, u.name, u.email, u.is_admin, u.created_at, u.updated_at
+        FROM comments c
+        JOIN users u ON c.user_id = u.id
+        WHERE c.post_id = ?
+        ORDER BY c.created_at ASC`
+	rows, err := r.db.Query(query, postID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var comments []*Comment
+	for rows.Next() {
+		c := &Comment{}
+		u := &User{}
+		if err := rows.Scan(&c.ID, &c.PostID, &c.UserID, &c.Content, &c.CreatedAt,
+			&u.ID, &u.Name, &u.Email, &u.IsAdmin, &u.CreatedAt, &u.UpdatedAt); err != nil {
+			return nil, err
+		}
+		c.User = u
+		comments = append(comments, c)
+	}
+	return comments, nil
+}


### PR DESCRIPTION
## Summary
- enable comments table in the database migrations
- add `Comment` model and repository
- add handler for creating and retrieving comments
- expose comment endpoints in `main.go`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684fd99569ac832bbc1c05f9767ee8ca